### PR TITLE
util: fix sms scheme according to RFC

### DIFF
--- a/util.go
+++ b/util.go
@@ -393,11 +393,8 @@ func IsBrowserCripplingCrossOriginCookies(r *http.Request) bool {
 }
 func SMSLinkURI(phone, body string, ua string) string {
 	qs := PlusToPercent20(url.Values{"body": {body}}.Encode())
-	if IsAndroidUA(ua) {
-		return "sms://" + phone + "/?" + qs
-	} else {
-		return "sms://" + phone + "/&" + qs
-	}
+	// https://www.rfc-editor.org/rfc/rfc5724#section-2.2
+	return "sms:" + phone + "?" + qs
 }
 func TweetIntentURL(body string, linkURL string) string {
 	q := url.Values{


### PR DESCRIPTION
SMS URI scheme does not contain `//` according to RFC5724:
```
  sms-uri        = scheme ":" sms-hier-part [ "?" sms-fields ]
  scheme         = "sms"
  sms-hier-part  = sms-recipient *( "," sms-recipient )
  sms-recipient  = telephone-subscriber ; defined in RFC 3966
  sms-fields     = sms-field *( "&" sms-field )
  sms-field      = sms-field-name "=" escaped-value
```